### PR TITLE
PlatformConfig: Base kernel path on SOMC_KERNEL_VERSION.

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -17,7 +17,7 @@ PLATFORM_COMMON_PATH := device/sony/ganges
 PRODUCT_PLATFORM_SOD := true
 
 TARGET_BOARD_PLATFORM := sdm660
-KERNEL_PATH := kernel/sony/msm-4.9
+KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 
 TARGET_ARCH := arm64
 TARGET_ARCH_VARIANT := armv8-a


### PR DESCRIPTION
Remove duplicate definition of the kernel version (which can and do get
out of sync when one attempts to change kernel versions).

Signed-off-by: MarijnS95 <marijns95@gmail.com>