### PR TITLE
platform: Disable enforcement of compatible props

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -34,6 +34,9 @@ DEVICE_PACKAGE_OVERLAYS += \
 AB_OTA_UPDATER := true
 TARGET_USES_HARDWARE_QCOM_BOOTCTRL := true
 
+# Disable enforcement of "compatible" properties until all props are fixed
+PRODUCT_COMPATIBLE_PROPERTY_OVERRIDE := false
+
 PRODUCT_SHIPPING_API_LEVEL := 27
 
 # A/B OTA dexopt package


### PR DESCRIPTION
Devices shipped with API level 27 or higher enforce usage of "compatible" properties by default (see build/make/core/config.mk).

Since not all of our software is ready yet, disable this enforcement for now.