### PR TITLE
[2/3] PlatformConfig: Enable FPC compilation.

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -106,7 +106,5 @@ BOARD_BUILD_SYSTEM_ROOT_IMAGE := true
 
 BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 
-TARGET_DEVICE_NO_FPC := true
-
 include device/sony/common/CommonConfig.mk
 


### PR DESCRIPTION
For https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/pull/49.

Now that the HAL for Ganges Egistec devices has been built, this flag
should be removed.