### PR TITLE
keylayout: remove camera button key mapping

### DIFF
--- a/rootdir/vendor/usr/keylayout/gpio-keys.kl
+++ b/rootdir/vendor/usr/keylayout/gpio-keys.kl
@@ -27,5 +27,3 @@
 
 key 115   VOLUME_UP
 key 114   VOLUME_DOWN
-key 528   FOCUS
-key 766   CAMERA


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>