### PR TITLE
usb_tether: switch to gsi

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -207,7 +207,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
     sys.usb.controller=a800000.dwc3 \
-    sys.usb.rndis.func.name=rndis_bam
+    sys.usb.rndis.func.name=gsi
 
 #WiFi MAC address path
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
on this platform there is gsi.dpl gsi.rmnet and gsi.rndis there is not rndis_bam also this breaks usb_tether on ganges

Signed-off-by: David Viteri <davidteri91@gmail.com>