### PR TITLE
init: Limit MTP rx/tx buffers to 16384

### DIFF
--- a/rootdir/vendor/etc/init/init.ganges.rc
+++ b/rootdir/vendor/etc/init/init.ganges.rc
@@ -41,6 +41,12 @@ on boot
     # CPU is isolated/hotplugged, the IRQ affinity is adjusted
     # to one of the CPU from the default IRQ affinity mask.
     write /proc/irq/default_smp_affinity f
+    
+    # MTP kernel parameters - needed so that swiotlb does not run OOM
+    chown system system /sys/module/usb_f_mtp/parameters/mtp_rx_req_len
+    chown system system /sys/module/usb_f_mtp/parameters/mtp_tx_req_len
+    write /sys/module/usb_f_mtp/parameters/mtp_rx_req_len 16384
+    write /sys/module/usb_f_mtp/parameters/mtp_tx_req_len 16384
 
 on property:sys.boot_completed=1
     # Runtime fs tuning for runtime performance


### PR DESCRIPTION
Limit rx/tx buffers to 16K to fix crashes when transferring files.

This is basically what we do on tone and loire.
[See here](https://github.com/sonyxperiadev/device-sony-tone/pull/184)