### PR TITLE
[GANGES] WCNSS: Enable concurrent STA/AP on wlan1 interface.

### DIFF
--- a/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
+++ b/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
@@ -94,6 +94,9 @@ ImplicitQosIsEnabled=0
 # Dual MAC feature is not supported in WCN3980
 gDualMacFeatureDisable=1
 
+# Turn on STA + AP/STA
+gEnableConcurrentSTA=wlan1
+
 # set Number of streams per VDEV for 2G 5G band as 1x1 mode
 gVdevTypeNss_2g=21845
 gVdevTypeNss_5g=21845


### PR DESCRIPTION
Configure WCNSS to expose a secondary interface, wlan1, which is used
for concurrent AP while wlan0 runs the STA.