### PR TITLE
[GANGES] platform: Enable graphics allocator and mapper v3.

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -31,6 +31,9 @@ TARGET_KEYMASTER_V4 := true
 DEVICE_PACKAGE_OVERLAYS += \
     $(PLATFORM_COMMON_PATH)/overlay
 
+# Graphics allocator/mapper v3
+TARGET_HARDWARE_GRAPHICS_V3 := true
+
 # A/B support
 AB_OTA_UPDATER := true
 


### PR DESCRIPTION
See https://github.com/sonyxperiadev/device-sony-common/pull/667
The HAL used for kernel 4.14 (8.1 branch) exports allocator and mapper
v3. Setting this property makes sure the vintf manifest represents this,
in turn allowing the system to use it.

Tested on Mermaid DSDS.

TODO: We should see if all platforms are compatible with v3 (most likely every platform is, only Loire on fbdev might be tricky) and remove this opt-in altogether, or turn it into an opt-out for unsupported platforms.