### PR TITLE
platform: Set optimal audio offload buffer size

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -168,6 +168,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.qti.sensors.max_mag_rate=false \
     ro.qti.sensors.max_geomag_rotv=50
 
+# Audio - QCOM HAL
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.audio.offload.buffer.size.kb=64
+
 ## sensor type
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.qti.sdk.sensors.gestures=false \


### PR DESCRIPTION
The optimal offload buffer size is 64kb on SDM630/6.