### PR TITLE
[GANGES] [Q-MR1] vendor: wifi: Enable magic packet WoWLAN trigger

### DIFF
--- a/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
+++ b/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
@@ -1,3 +1,4 @@
 disable_scan_offload=1
 p2p_disabled=1
 tdls_external_control=1
+wowlan_triggers=magic_pkt


### PR DESCRIPTION
This allows to trigger wakeup on Wake-on-WLAN magic packet,
ensuring wifi connection stability and solving disconnections
during platform deep sleep.