### PR TITLE
platform.mk: Add sscrpcd flag

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -87,6 +87,9 @@ DEVICE_PACKAGE_OVERLAYS += \
 # Graphics allocator/mapper v3
 TARGET_HARDWARE_GRAPHICS_V3 := true
 
+# Sscrpcd
+TARGET_NEEDS_SSCRPCD := true
+
 # A/B support
 AB_OTA_UPDATER := true
 


### PR DESCRIPTION
#860 in common changes how those modules are enabled.
It adds flags thus we have to follow the changes into
device trees for platform and make sure the needed flags are
set.