### PR TITLE
[master] platform: Disable camera dual isp sync

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -224,6 +224,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.qcom.bluetooth.soc=cherokee
 
+# Camera
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.vendor.camera.dual.isp.sync=0
+
 # Fluence
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.qc.sdk.audio.fluencetype=fluence


### PR DESCRIPTION
SDM660 platform does not support camera dual isp sync.

Setting this property allows us to avoid introducing
workrounds on the kernel side as it was done in the
4.14 kernel.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>